### PR TITLE
Revert php version to 7.1+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: php
 
 php:
+  - 7.1
+  - 7.2
+  - 7.3
   - 7.4
   - 8.0
   - nightly

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
     }
   },
   "require": {
-    "php": "^7.4 || ^8.0",
+    "php": "^7.1 || ^7.2 || ^7.3 || ^7.4 || ^8.0",
     "ext-mbstring": "*",
     "sabberworm/php-css-parser": "^8.4"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.5"
+    "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5"
   }
 }


### PR DESCRIPTION
Running a PHP lint Github action, that ended with error, I discovered that `php-svg-lib`, which DOMPDF depends on, requires php version [`7.4`](https://github.com/dompdf/php-svg-lib/blob/3ffbbb037f0871c3a819e90cff8b36dd7e656189/composer.json#L24) when DOMPDF minimum version is [`7.1`](https://github.com/dompdf/dompdf/blob/5a72ddd8a7c5408c9e1ba586520910cf22c9db1f/composer.json#L35). Also PHPUnit version isn't matching because version [`9.5`](https://github.com/dompdf/php-svg-lib/blob/3ffbbb037f0871c3a819e90cff8b36dd7e656189/composer.json#L29) requires PHP version `7.3`.

This PR addresses this issue be setting `php-svg-lib` and `phpunit` to PHP minimum version of `7.1` to match the DOMPDF one.

