### PR TITLE
Improve color parsing

### DIFF
--- a/src/Svg/DefaultStyle.php
+++ b/src/Svg/DefaultStyle.php
@@ -10,11 +10,11 @@ namespace Svg;
 
 class DefaultStyle extends Style
 {
-    public $color = '';
+    public $color = [0, 0, 0, 1];
     public $opacity = 1.0;
     public $display = 'inline';
 
-    public $fill = 'black';
+    public $fill = [0, 0, 0, 1];
     public $fillOpacity = 1.0;
     public $fillRule = 'nonzero';
 

--- a/tests/Svg/StyleTest.php
+++ b/tests/Svg/StyleTest.php
@@ -17,17 +17,26 @@ class StyleTest extends TestCase
     public function test_parseColor()
     {
         $this->assertEquals("none", Style::parseColor("none"));
-        $this->assertEquals(array(255, 0, 0), Style::parseColor("RED"));
-        $this->assertEquals(array(0, 0, 255), Style::parseColor("blue"));
+        $this->assertEquals("currentcolor", Style::parseColor("currentcolor"));
+        $this->assertEquals(array(255, 0, 0, 1), Style::parseColor("RED"));
+        $this->assertEquals(array(0, 0, 255, 1), Style::parseColor("blue"));
+        $this->assertEquals(array(0, 0, 0, 1), Style::parseColor("black"));
+        $this->assertEquals(array(255, 255, 255, 1), Style::parseColor("white"));
+
         $this->assertEquals(null, Style::parseColor("foo"));
-        $this->assertEquals(array(0, 0, 0), Style::parseColor("black"));
-        $this->assertEquals(array(255, 255, 255), Style::parseColor("white"));
-        $this->assertEquals(array(0, 0, 0), Style::parseColor("#000000"));
-        $this->assertEquals(array(255, 255, 255), Style::parseColor("#ffffff"));
-        $this->assertEquals(array(0, 0, 0), Style::parseColor("rgb(0,0,0)"));
-        $this->assertEquals(array(255, 255, 255), Style::parseColor("rgb(255,255,255)"));
-        $this->assertEquals(array(0, 0, 0), Style::parseColor("rgb(0, 0, 0)"));
-        $this->assertEquals(array(255, 255, 255), Style::parseColor("rgb(255, 255, 255)"));
+
+        $this->assertEquals(array(0, 0, 0, 1), Style::parseColor("#000000"));
+        $this->assertEquals(array(255, 255, 255, 1), Style::parseColor("#ffffff"));
+        $this->assertEquals(array(0, 0, 0, .5), Style::parseColor("#00000080"));
+
+        $this->assertEquals(array(0, 0, 0, 1), Style::parseColor("rgb(0,0,0)"));
+        $this->assertEquals(array(255, 255, 255, 1), Style::parseColor("rgb(255,255,255)"));
+        $this->assertEquals(array(0, 0, 0, 1), Style::parseColor("rgb(0, 0, 0)"));
+        $this->assertEquals(array(255, 255, 255, 1), Style::parseColor("rgb(255, 255, 255)"));
+        $this->assertEquals(array(255, 255, 255, .5), Style::parseColor("rgb(255, 255, 255, .5)"));
+
+        $this->assertEquals(array(255, 0, 0, 1), Style::parseColor("hsl(0, 100%, 50%)"));
+        $this->assertEquals(array(255, 0, 0, .5), Style::parseColor("hsl(0, 100%, 50%, .5)"));
     }
 
     public function test_fromAttributes()
@@ -42,8 +51,8 @@ class StyleTest extends TestCase
 
         $style->fromAttributes($attributes);
 
-        $this->assertEquals(array(0, 0, 255), $style->color);
-        $this->assertEquals(array(255, 255, 255), $style->fill);
+        $this->assertEquals(array(0, 0, 255, 1), $style->color);
+        $this->assertEquals(array(255, 255, 255, 1), $style->fill);
         $this->assertEquals("none", $style->stroke);
     }
 


### PR DESCRIPTION
- use correct format for default fill color
- set default color to black for better currentcolor support
- add support for alpha (hex, rgba, hsla)

fixes #24
fixes #68