### PR TITLE
Support non-namespaced href attribute

### DIFF
--- a/src/Svg/Tag/Image.php
+++ b/src/Svg/Tag/Image.php
@@ -52,6 +52,10 @@ class Image extends AbstractTag
             $this->href = $attributes['xlink:href'];
         }
 
+        if (isset($attributes['href'])) {
+            $this->href = $attributes['href'];
+        }
+
         $this->document->getSurface()->transform(1, 0, 0, -1, 0, $height);
 
         $this->document->getSurface()->drawImage($this->href, $this->x, $this->y, $this->width, $this->height);

--- a/src/Svg/Tag/UseTag.php
+++ b/src/Svg/Tag/UseTag.php
@@ -38,7 +38,7 @@ class UseTag extends AbstractTag
 
         $document = $this->getDocument();
 
-        $link = $attributes["xlink:href"];
+        $link = $attributes["href"] ?? $attributes["xlink:href"];
         $this->reference = $document->getDef($link);
 
         if ($this->reference) {


### PR DESCRIPTION
The SVG 2 specification deprecated usage of the xlink namespace when specifying resource references (href attribute) in supported SVG elements.
https://svgwg.org/svg2-draft/linking.html#XLinkRefAttrs