### PR TITLE
Update Path.php to avoid division by 0 error

### DIFF
--- a/src/Svg/Tag/Path.php
+++ b/src/Svg/Tag/Path.php
@@ -480,6 +480,12 @@ class Path extends Shape
 
         $px = -$cosTh * $toX * 0.5 - $sinTh * $toY * 0.5;
         $py = -$cosTh * $toY * 0.5 + $sinTh * $toX * 0.5;
+        
+        $ry = $ry ? $ry : 0.1;
+        $py = $py ? $py : 0.1;
+        $rx = $rx ? $rx : 0.1;
+        $px = $px ? $px : 0.1;
+        
         $rx2 = $rx * $rx;
         $ry2 = $ry * $ry;
         $py2 = $py * $py;


### PR DESCRIPTION
As per https://github.com/dompdf/php-svg-lib/issues/97

This pull request adds a small offset to $rx, $ry, $px, and $py to avoid the division by 0 error, as suggested by @ljadrbln