### PR TITLE
Update PathTest.php for PHPunit compatibility

### DIFF
--- a/tests/Svg/PathTest.php
+++ b/tests/Svg/PathTest.php
@@ -10,7 +10,7 @@ use Svg\Tag\Path;
 
 final class PathTest extends TestCase
 {
-    public function commandProvider(): array
+    public static function commandProvider(): array
     {
         return [
             'parse a relative arc with the shorthand format' => [


### PR DESCRIPTION
PHPunit 10 at Debian:

1 test triggered 1 PHPUnit deprecation:

1) Svg\Tests\PathTest::testParseCommands
Data Provider method Svg\Tests\PathTest::commandProvider() is not static


There is no backwards incompatible changes. Same as https://github.com/dompdf/dompdf/pull/3275